### PR TITLE
Update lake metrics definitions

### DIFF
--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -1139,6 +1139,16 @@ entities:
         data-max: NA
         data-units: Julian day
       -
+        attr-label: date_below_5
+        attr-def: >-
+          First date following the peak temperature date where the average surface 
+          temperature drops below 5 degrees C. NA means that there were no dates 
+          under 5 degrees C following the peak temperature for that year.
+        attr-defs: Wismer and Christie, 1987
+        data-min: NA
+        data-max: NA
+        data-units: Julian day
+      -
         attr-label: SmetaTopD_mean
         attr-def: >- 
           Mean epilmnion meters during the longest stratified period. It uses the 

--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -1110,6 +1110,97 @@ entities:
         data-max: NA
         data-units: degrees C
       -
+        attr-label: spring_days_in_10.5_15.5
+        attr-def: >-
+          Duration of optimal incubation period where surface temperature
+          is between 10.5-15.5 degrees C (Spring only)
+        attr-defs: Wismer and Christie, 1987
+        data-min: NA
+        data-max: NA
+        data-units: days before June 1
+      -
+        attr-label: post_ice_warm_rate
+        attr-def: >-
+          Average change in surface temp (degrees C per day) 30 days post ice off.
+          This will be NA if there is no ice-off date.
+        attr-defs: Busch et al., 1975; Madenijan et al., 1996
+        data-min: NA
+        data-max: NA
+        data-units: degrees C per day
+      -
+        attr-label: date_over_{temp}
+        attr-def: >-
+          Date where average surface temperature reaches {temp} degrees C. {temp} is
+          one of 8.9 (date of spawning temp), 16.7 (hatch date), 18 (date of spawning
+          temp for bass), or 21 (date of spawning temp for bass). NA means that there
+          were no dates over that temperature for that year.
+        attr-defs: Wismer and Christie, 1987
+        data-min: NA
+        data-max: NA
+        data-units: Julian day
+      -
+        attr-label: SmetaTopD_mean
+        attr-def: >- 
+          Mean epilmnion meters during the longest stratified period. It uses the 
+          longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
+        attr-defs: Read et al., 2011
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: SmetaBotD_mean
+        attr-def: >-
+          Mean hypolimnion meters during the longest stratified period. It uses the 
+          longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
+        attr-defs: Read et al., 2011
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: mean_epi_vol
+        attr-def: >-
+          Mean epilmnion volume during longest stratified period. It uses the 
+          longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
+        attr-defs: Read et al., 2021
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: mean_hyp_vol
+        attr-def: >- 
+          Mean hypolimnion volume during longest stratified period. It uses the 
+          longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
+        attr-defs: Read et al., 2021
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: mean_epi_hypo_ratio
+        attr-def: >- 
+          Mean epilmnion volume divided by mean hypolimnion volume. It uses the 
+          longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
+        attr-defs: Read et al., 2021
+        data-min: NA
+        data-max: NA
+        data-units: unitless (ratio)
+      -
+        attr-label: open_water_duration
+        attr-def: >-
+          Number of days between ice-off for this year's winter season and ice-on
+          for the next year's winter season. If `NA`, the open water period could
+          not be calculated because there was either not an ice-off date for this
+          year's winter season or an ice-on date for the next year's winter season
+          or both were missing.
+        attr-defs: Read et al., 2021
+        data-min: NA
+        data-max: NA
+        data-units: days
+      -
         attr-label: height_6.4_11.8
         attr-def: >-
           Annual sum of the daily water column height between 6.4 and 11.8 degrees C.
@@ -1915,97 +2006,6 @@ entities:
           Days in which there is any part of water column between 30 and 31 degrees C.
           This range is used to denote adult optimum
         attr-defs: Wismer and Christie, 1987
-        data-min: NA
-        data-max: NA
-        data-units: days
-      -
-        attr-label: spring_days_in_10.5_15.5
-        attr-def: >-
-          Duration of optimal incubation period where surface temperature
-          is between 10.5-15.5 degrees C (Spring only)
-        attr-defs: Wismer and Christie, 1987
-        data-min: NA
-        data-max: NA
-        data-units: days before June 1
-      -
-        attr-label: post_ice_warm_rate
-        attr-def: >-
-          Average change in surface temp (degrees C per day) 30 days post ice off.
-          This will be NA if there is no ice-off date.
-        attr-defs: Busch et al., 1975; Madenijan et al., 1996
-        data-min: NA
-        data-max: NA
-        data-units: degrees C per day
-      -
-        attr-label: date_over_{temp}
-        attr-def: >-
-          Date where average surface temperature reaches {temp} degrees C. {temp} is
-          one of 8.9 (date of spawning temp), 16.7 (hatch date), 18 (date of spawning
-          temp for bass), or 21 (date of spawning temp for bass). NA means that there
-          were no dates over that temperature for that year.
-        attr-defs: Wismer and Christie, 1987
-        data-min: NA
-        data-max: NA
-        data-units: Julian day
-      -
-        attr-label: SmetaTopD_mean
-        attr-def: >- 
-          Mean epilmnion meters during the longest stratified period. It uses the 
-          longest duration of stratified days as the stratified period and will
-          return NA for any stratified period less than 30 days.
-        attr-defs: Read et al., 2011
-        data-min: NA
-        data-max: NA
-        data-units: linear distance (m)
-      -
-        attr-label: SmetaBotD_mean
-        attr-def: >-
-          Mean hypolimnion meters during the longest stratified period. It uses the 
-          longest duration of stratified days as the stratified period and will
-          return NA for any stratified period less than 30 days.
-        attr-defs: Read et al., 2011
-        data-min: NA
-        data-max: NA
-        data-units: linear distance (m)
-      -
-        attr-label: mean_epi_vol
-        attr-def: >-
-          Mean epilmnion volume during longest stratified period. It uses the 
-          longest duration of stratified days as the stratified period and will
-          return NA for any stratified period less than 30 days.
-        attr-defs: Read et al., 2021
-        data-min: NA
-        data-max: NA
-        data-units: volume (m^3*1000)
-      -
-        attr-label: mean_hyp_vol
-        attr-def: >- 
-          Mean hypolimnion volume during longest stratified period. It uses the 
-          longest duration of stratified days as the stratified period and will
-          return NA for any stratified period less than 30 days.
-        attr-defs: Read et al., 2021
-        data-min: NA
-        data-max: NA
-        data-units: volume (m^3*1000)
-      -
-        attr-label: mean_epi_hypo_ratio
-        attr-def: >- 
-          Mean epilmnion volume divided by mean hypolimnion volume. It uses the 
-          longest duration of stratified days as the stratified period and will
-          return NA for any stratified period less than 30 days.
-        attr-defs: Read et al., 2021
-        data-min: NA
-        data-max: NA
-        data-units: unitless (ratio)
-      -
-        attr-label: open_water_duration
-        attr-def: >-
-          Number of days between ice-off for this year's winter season and ice-on
-          for the next year's winter season. If `NA`, the open water period could
-          not be calculated because there was either not an ice-off date for this
-          year's winter season or an ice-on date for the next year's winter season
-          or both were missing.
-        attr-defs: Read et al., 2021
         data-min: NA
         data-max: NA
         data-units: days

--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -973,7 +973,9 @@ entities:
           date actually occurs in the previous year (e.g. ice-on for winter of 2017 happened
           in December of 2016). This definition of ice-on is consistent with the Wisconsin
           State Climatology Office's use of ice-on and ice-off dates by winter season. If
-          this value is `NA`, it means that no ice formed during that winter season.
+          this value is `NA`, it means that no ice formed during that winter season or that it
+          is the first year in the set and cannot be determined since we do not data for that
+          year's full winter season.
         attr-defs: Read et al., 2021
         data-min: NA
         data-max: NA
@@ -991,21 +993,26 @@ entities:
         attr-label: winter_dur_0_4
         attr-def: >-
           Number of days, beginning October 30 of the previous year and running through June
-          of the given year, that surface water is <4 degrees C
+          of the given year, that surface water is <4 degrees C. This is `NA` for the first
+          year of every dataset because we do not data for that year's full winter season.
         attr-defs: Read et al., 2021
         data-min: NA
         data-max: NA
         data-units: days
       -
         attr-label: coef_var_31_60
-        attr-def: Coefficient of Variation of surface temperature from 30-60 days post ice off
+        attr-def: >- 
+          Coefficient of Variation of surface temperature from 30-60 days post ice off. If 
+          `ice_off_date` is `NA`, then this column will also be `NA`.
         attr-defs: Read et al., 2021
         data-min: NA
         data-max: NA
         data-units: unitless (CV)
       -
         attr-label: coef_var_1_30
-        attr-def: Coefficient of Variation of surface temperature up to 30 days post ice-off
+        attr-def: >- 
+          Coefficient of Variation of surface temperature up to 30 days post ice-off. If 
+          `ice_off_date` is `NA`, then this column will also be `NA`.
         attr-defs: Read et al., 2021
         data-min: NA
         data-max: NA
@@ -1029,7 +1036,8 @@ entities:
         attr-def: >- 
           Average thermocline depth in stratified period that is >= 30 days. It
           uses the longest duration of stratified days as the stratified period and will
-          return NA for any stratified period less than 30 days.
+          return NA for any stratified period less than 30 days. NAs will also be 
+          returned if there is no thermocline found.
         attr-defs: Read et al., 2021 
         data-min: NA
         data-max: NA
@@ -1922,7 +1930,8 @@ entities:
       -
         attr-label: post_ice_warm_rate
         attr-def: >-
-          Average change in surface temp (degrees C per day) 30 days post ice off
+          Average change in surface temp (degrees C per day) 30 days post ice off.
+          This will be NA if there is no ice-off date.
         attr-defs: Busch et al., 1975; Madenijan et al., 1996
         data-min: NA
         data-max: NA
@@ -1932,42 +1941,58 @@ entities:
         attr-def: >-
           Date where average surface temperature reaches {temp} degrees C. {temp} is
           one of 8.9 (date of spawning temp), 16.7 (hatch date), 18 (date of spawning
-          temp for bass), or 21 (date of spawning temp for bass).
+          temp for bass), or 21 (date of spawning temp for bass). NA means that there
+          were no dates over that temperature for that year.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
         data-units: Julian day
       -
         attr-label: SmetaTopD_mean
-        attr-def: Mean epilmnion meters during the longest stratified period
+        attr-def: >- 
+          Mean epilmnion meters during the longest stratified period. It uses the 
+          longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
         attr-defs: Read et al., 2011
         data-min: NA
         data-max: NA
         data-units: linear distance (m)
       -
         attr-label: SmetaBotD_mean
-        attr-def: Mean hypolimnion meters during the longest stratified period
+        attr-def: >-
+          Mean hypolimnion meters during the longest stratified period. It uses the 
+          longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
         attr-defs: Read et al., 2011
         data-min: NA
         data-max: NA
         data-units: linear distance (m)
       -
         attr-label: mean_epi_vol
-        attr-def: Mean epilmnion volume during longest stratified period
+        attr-def: >-
+          Mean epilmnion volume during longest stratified period. It uses the 
+          longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
         attr-defs: Read et al., 2021
         data-min: NA
         data-max: NA
         data-units: volume (m^3*1000)
       -
         attr-label: mean_hyp_vol
-        attr-def: Mean hypolimnion volume during longest stratified period
+        attr-def: >- 
+          Mean hypolimnion volume during longest stratified period. It uses the 
+          longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
         attr-defs: Read et al., 2021
         data-min: NA
         data-max: NA
         data-units: volume (m^3*1000)
       -
         attr-label: mean_epi_hypo_ratio
-        attr-def: Mean epilmnion volume divided by mean hypolimnion volume
+        attr-def: >- 
+          Mean epilmnion volume divided by mean hypolimnion volume. It uses the 
+          longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
         attr-defs: Read et al., 2021
         data-min: NA
         data-max: NA

--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -1096,7 +1096,7 @@ entities:
       -
         attr-label: height_6.4_11.8
         attr-def: >-
-          Meters of water between 6.4 and 11.8 degrees C.
+          Meters of the water column between 6.4 and 11.8 degrees C.
           This range is used to denote lower good-growth temperature (cold thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1105,7 +1105,7 @@ entities:
       -
         attr-label: vol_6.4_11.8
         attr-def: >-
-          Volume of water between 6.4 and 11.8 degrees C.
+          Volume of the waterbody between 6.4 and 11.8 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1122,7 +1122,7 @@ entities:
       -
         attr-label: height_13.2_18.2
         attr-def: >-
-          Meters of water between 13.2 and 18.2 degrees C.
+          Meters of the water column between 13.2 and 18.2 degrees C.
           This range is used to denote lower good-growth temperature (cool thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1131,7 +1131,7 @@ entities:
       -
         attr-label: vol_13.2_18.2
         attr-def: >-
-          Volume of water between 13.2 and 18.2 degrees C.
+          Volume of the waterbody between 13.2 and 18.2 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1148,7 +1148,7 @@ entities:
       -
         attr-label: height_17.7_22.5
         attr-def: >-
-          Meters of water between 17.7 and 22.5 degrees C.
+          Meters of the water column between 17.7 and 22.5 degrees C.
           This range is used to denote lower good-growth temperature (warm thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1157,7 +1157,7 @@ entities:
       -
         attr-label: vol_17.7_22.5
         attr-def: >-
-          Volume of water between 17.7 and 22.5 degrees C.
+          Volume of the waterbody between 17.7 and 22.5 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1174,7 +1174,7 @@ entities:
       -
         attr-label: height_11.5_18.7
         attr-def: >-
-          Meters of water between 11.5 and 18.7 degrees C.
+          Meters of the water column between 11.5 and 18.7 degrees C.
           This range is used to denote optimum temperature (cold thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1183,7 +1183,7 @@ entities:
       -
         attr-label: vol_11.5_18.7
         attr-def: >-
-          Volume of water between 11.5 and 18.7 degrees C.
+          Volume of the waterbody between 11.5 and 18.7 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1200,7 +1200,7 @@ entities:
       -
         attr-label: height_24_25.7
         attr-def: >-
-          Meters of water between 24 and 25.7 degrees C.
+          Meters of the water column between 24 and 25.7 degrees C.
           This range is used to denote optimum temperature (cool thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1209,7 +1209,7 @@ entities:
       -
         attr-label: vol_24_25.7
         attr-def: >-
-          Volume of water between 24 and 25.7 degrees C.
+          Volume of the waterbody between 24 and 25.7 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1226,7 +1226,7 @@ entities:
       -
         attr-label: height_27_32
         attr-def: >-
-          Meters of water between 27 and 32 degrees C.
+          Meters of the water column between 27 and 32 degrees C.
           This range is used to denote optimum temperature (warm thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1235,7 +1235,7 @@ entities:
       -
         attr-label: vol_27_32
         attr-def: >-
-          Volume of water between 27 and 32 degrees C.
+          Volume of the waterbody between 27 and 32 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1252,7 +1252,7 @@ entities:
       -
         attr-label: height_15.5_21.2
         attr-def: >-
-          Meters of water between 15.5 and 21.2 degrees C.
+          Meters of the water column between 15.5 and 21.2 degrees C.
           This range is used to denote upper good growth temperature (cold thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1261,7 +1261,7 @@ entities:
       -
         attr-label: vol_15.5_21.2
         attr-def: >-
-          Volume of water between 15.5 and 21.2 degrees C.
+          Volume of the waterbody between 15.5 and 21.2 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1278,7 +1278,7 @@ entities:
       -
         attr-label: height_27.7_28.8
         attr-def: >-
-          Meters of water between 27.7 and 28.8 degrees C.
+          Meters of the water column between 27.7 and 28.8 degrees C.
           This range is used to denote upper good growth temperature (cool thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1287,7 +1287,7 @@ entities:
       -
         attr-label: vol_27.7_28.8
         attr-def: >-
-          Volume of water between 27.7 and 28.8 degrees C.
+          Volume of the waterbody between 27.7 and 28.8 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1304,7 +1304,7 @@ entities:
       -
         attr-label: height_31.3_34.7
         attr-def: >-
-          Meters of water between 31.3 and 34.7 degrees C.
+          Meters of the water column between 31.3 and 34.7 degrees C.
           This range is used to denote upper good growth temperature (warm thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1313,7 +1313,7 @@ entities:
       -
         attr-label: vol_31.3_34.7
         attr-def: >-
-          Volume of water between 31.3 and 34.7 degrees C.
+          Volume of the waterbody between 31.3 and 34.7 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1330,7 +1330,7 @@ entities:
       -
         attr-label: height_26.6_100
         attr-def: >-
-          Meters of water between 26.6 and 100 degrees C.
+          Meters of the water column between 26.6 and 100 degrees C.
           This range is used to denote upper lethal temperature (cold thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1339,7 +1339,7 @@ entities:
       -
         attr-label: vol_26.6_100
         attr-def: >-
-          Volume of water between 26.6 and 100 degrees C.
+          Volume of the waterbody between 26.6 and 100 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1356,7 +1356,7 @@ entities:
       -
         attr-label: height_32.3_100
         attr-def: >-
-          Meters of water between 32.3 and 100 degrees C.
+          Meters of the water column between 32.3 and 100 degrees C.
           This range is used to denote upper lethal temperature (cool thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1365,7 +1365,7 @@ entities:
       -
         attr-label: vol_32.3_100
         attr-def: >-
-          Volume of water between 32.3 and 100 degrees C.
+          Volume of the waterbody between 32.3 and 100 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1382,7 +1382,7 @@ entities:
       -
         attr-label: height_36_100
         attr-def: >-
-          Meters of water between 36 and 100 degrees C.
+          Meters of the water column between 36 and 100 degrees C.
           This range is used to denote upper lethal temperature (warm thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1391,7 +1391,7 @@ entities:
       -
         attr-label: vol_36_100
         attr-def: >-
-          Volume of water between 36 and 100 degrees C.
+          Volume of the waterbody between 36 and 100 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1408,7 +1408,7 @@ entities:
       -
         attr-label: height_12_28
         attr-def: >-
-          Meters of water between 12 and 28 degrees C.
+          Meters of the water column between 12 and 28 degrees C.
           This range is used to denote optimal age 0 thermal habitat
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1417,7 +1417,7 @@ entities:
       -
         attr-label: vol_12_28
         attr-def: >-
-          Volume of water between 12 and 28 degrees C.
+          Volume of the waterbody between 12 and 28 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1434,7 +1434,7 @@ entities:
       -
         attr-label: height_10.6_11.2
         attr-def: >-
-          Meters of water between 10.6 and 11.2 degrees C.
+          Meters of the water column between 10.6 and 11.2 degrees C.
           This range is used to denote optimal larval thermal habitat
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1443,7 +1443,7 @@ entities:
       -
         attr-label: vol_10.6_11.2
         attr-def: >-
-          Volume of water between 10.6 and 11.2 degrees C.
+          Volume of the waterbody between 10.6 and 11.2 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1460,7 +1460,7 @@ entities:
       -
         attr-label: height_18.2_28.2
         attr-def: >-
-          Meters of water between 18.2 and 28.2 degrees C.
+          Meters of the water column between 18.2 and 28.2 degrees C.
           This range is used to denote good growth habitat
         attr-defs: Fang et al., 2004
         data-min: NA
@@ -1469,7 +1469,7 @@ entities:
       -
         attr-label: vol_18.2_28.2
         attr-def: >-
-          Volume of water between 18.2 and 28.2 degrees C.
+          Volume of the waterbody between 18.2 and 28.2 degrees C.
         attr-defs: Fang et al., 2004
         data-min: NA
         data-max: NA
@@ -1486,7 +1486,7 @@ entities:
       -
         attr-label: height_18_22
         attr-def: >-
-          Meters of water between 18 and 22 degrees C.
+          Meters of the water column between 18 and 22 degrees C.
           This range is used to denote optimal age 0 thermal habitat
         attr-defs: Christie and Regier, 1988
         data-min: NA
@@ -1495,7 +1495,7 @@ entities:
       -
         attr-label: vol_18_22
         attr-def: >-
-          Volume of water between 18 and 22 degrees C.
+          Volume of the waterbody between 18 and 22 degrees C.
         attr-defs: Christie and Regier, 1988
         data-min: NA
         data-max: NA
@@ -1512,7 +1512,7 @@ entities:
       -
         attr-label: height_19.3_23.3
         attr-def: >-
-          Meters of water between 19.3 and 23.3 degrees C.
+          Meters of the water column between 19.3 and 23.3 degrees C.
           This range is used to denote YOY optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1521,7 +1521,7 @@ entities:
       -
         attr-label: vol_19.3_23.3
         attr-def: >-
-          Volume of water between 19.3 and 23.3 degrees C.
+          Volume of the waterbody between 19.3 and 23.3 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1538,7 +1538,7 @@ entities:
       -
         attr-label: height_19_23
         attr-def: >-
-          Meters of water between 19 and 23 degrees C.
+          Meters of the water column between 19 and 23 degrees C.
           This range is used to denote optimal thermal habitat
         attr-defs: Cline et al., 2013
         data-min: NA
@@ -1547,7 +1547,7 @@ entities:
       -
         attr-label: vol_19_23
         attr-def: >-
-          Volume of water between 19 and 23 degrees C.
+          Volume of the waterbody between 19 and 23 degrees C.
         attr-defs: Cline et al., 2013
         data-min: NA
         data-max: NA
@@ -1564,7 +1564,7 @@ entities:
       -
         attr-label: height_20.6_23.2
         attr-def: >-
-          Meters of water between 20.6 and 23.2 degrees C.
+          Meters of the water column between 20.6 and 23.2 degrees C.
           This range is used to denote optimal thermal habitat
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1573,7 +1573,7 @@ entities:
       -
         attr-label: vol_20.6_23.2
         attr-def: >-
-          Volume of water between 20.6 and 23.2 degrees C.
+          Volume of the waterbody between 20.6 and 23.2 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1590,7 +1590,7 @@ entities:
       -
         attr-label: height_20_30
         attr-def: >-
-          Meters of water between 20 and 30 degrees C.
+          Meters of the water column between 20 and 30 degrees C.
           This range is used to denote larval optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1599,7 +1599,7 @@ entities:
       -
         attr-label: vol_20_30
         attr-def: >-
-          Volume of water between 20 and 30 degrees C.
+          Volume of the waterbody between 20 and 30 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1616,7 +1616,7 @@ entities:
       -
         attr-label: height_21_100
         attr-def: >-
-          Meters of water between 21 and 100 degrees C.
+          Meters of the water column between 21 and 100 degrees C.
           This range is used to denote growing season for YOY
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1625,7 +1625,7 @@ entities:
       -
         attr-label: vol_21_100
         attr-def: >-
-          Volume of water between 21 and 100 degrees C.
+          Volume of the waterbody between 21 and 100 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1642,7 +1642,7 @@ entities:
       -
         attr-label: height_22_23
         attr-def: >-
-          Meters of water between 22 and 23 degrees C.
+          Meters of the water column between 22 and 23 degrees C.
           This range is used to denote optimal thermal habitat
         attr-defs: Casselman, 2002
         data-min: NA
@@ -1651,7 +1651,7 @@ entities:
       -
         attr-label: vol_22_23
         attr-def: >-
-          Volume of water between 22 and 23 degrees C.
+          Volume of the waterbody between 22 and 23 degrees C.
         attr-defs: Casselman, 2002
         data-min: NA
         data-max: NA
@@ -1668,7 +1668,7 @@ entities:
       -
         attr-label: height_23_31
         attr-def: >-
-          Meters of water between 23 and 31 degrees C.
+          Meters of the water column between 23 and 31 degrees C.
           This range is used to denote juvenile optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1677,7 +1677,7 @@ entities:
       -
         attr-label: vol_23_31
         attr-def: >-
-          Volume of water between 23 and 31 degrees C.
+          Volume of the waterbody between 23 and 31 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1694,7 +1694,7 @@ entities:
       -
         attr-label: height_25_29
         attr-def: >-
-          Meters of water between 25 and 29 degrees C.
+          Meters of the water column between 25 and 29 degrees C.
           This range is used to denote larval optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1703,7 +1703,7 @@ entities:
       -
         attr-label: vol_25_29
         attr-def: >-
-          Volume of water between 25 and 29 degrees C.
+          Volume of the waterbody between 25 and 29 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1720,7 +1720,7 @@ entities:
       -
         attr-label: height_26.2_32
         attr-def: >-
-          Meters of water between 26.2 and 32 degrees C.
+          Meters of the water column between 26.2 and 32 degrees C.
           This range is used to denote good growth habitat
         attr-defs: Countant, 1977
         data-min: NA
@@ -1729,7 +1729,7 @@ entities:
       -
         attr-label: vol_26.2_32
         attr-def: >-
-          Volume of water between 26.2 and 32 degrees C.
+          Volume of the waterbody between 26.2 and 32 degrees C.
         attr-defs: Countant, 1977
         data-min: NA
         data-max: NA
@@ -1746,7 +1746,7 @@ entities:
       -
         attr-label: height_26_28
         attr-def: >-
-          Meters of water between 26 and 28 degrees C.
+          Meters of the water column between 26 and 28 degrees C.
           This range is used to denote subadult optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1755,7 +1755,7 @@ entities:
       -
         attr-label: vol_26_28
         attr-def: >-
-          Volume of water between 26 and 28 degrees C.
+          Volume of the waterbody between 26 and 28 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1772,7 +1772,7 @@ entities:
       -
         attr-label: height_26_30
         attr-def: >-
-          Meters of water between 26 and 30 degrees C.
+          Meters of the water column between 26 and 30 degrees C.
           This range is used to denote adult optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1781,7 +1781,7 @@ entities:
       -
         attr-label: vol_26_30
         attr-def: >-
-          Volume of water between 26 and 30 degrees C.
+          Volume of the waterbody between 26 and 30 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1798,7 +1798,7 @@ entities:
       -
         attr-label: height_28_29
         attr-def: >-
-          Meters of water between 28 and 29 degrees C.
+          Meters of the water column between 28 and 29 degrees C.
           This range is used to denote juvenile optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1807,7 +1807,7 @@ entities:
       -
         attr-label: vol_28_29
         attr-def: >-
-          Volume of water between 28 and 29 degrees C.
+          Volume of the waterbody between 28 and 29 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1825,7 +1825,7 @@ entities:
       -
         attr-label: height_28_32
         attr-def: >-
-          Meters of water between 28 and 32 degrees C.
+          Meters of the water column between 28 and 32 degrees C.
           This range is used to denote juvenile optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1834,7 +1834,7 @@ entities:
       -
         attr-label: vol_28_32
         attr-def: >-
-          Volume of water between 28 and 32 degrees C.
+          Volume of the waterbody between 28 and 32 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1852,7 +1852,7 @@ entities:
       -
         attr-label: height_29_100
         attr-def: >-
-          Meters of water between 29 and 100 degrees C.
+          Meters of the water column between 29 and 100 degrees C.
           This range is used to denote lethal habitat
         attr-defs: Fang et al., 2004
         data-min: NA
@@ -1861,7 +1861,7 @@ entities:
       -
         attr-label: vol_29_100
         attr-def: >-
-          Volume of water between 29 and 100 degrees C.
+          Volume of the waterbody between 29 and 100 degrees C.
         attr-defs: Fang et al., 2004
         data-min: NA
         data-max: NA
@@ -1879,7 +1879,7 @@ entities:
       -
         attr-label: height_30_31
         attr-def: >-
-          Meters of water between 30 and 31 degrees C.
+          Meters of the water column between 30 and 31 degrees C.
           This range is used to denote adult optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1888,7 +1888,7 @@ entities:
       -
         attr-label: vol_30_31
         attr-def: >-
-          Volume of water between 30 and 31 degrees C.
+          Volume of the waterbody between 30 and 31 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA

--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -1096,7 +1096,7 @@ entities:
       -
         attr-label: height_6.4_11.8
         attr-def: >-
-          Meters of the water column between 6.4 and 11.8 degrees C.
+          Annual sum of the daily water column height between 6.4 and 11.8 degrees C.
           This range is used to denote lower good-growth temperature (cold thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1105,7 +1105,7 @@ entities:
       -
         attr-label: vol_6.4_11.8
         attr-def: >-
-          Volume of the waterbody between 6.4 and 11.8 degrees C.
+          Annual sum of the daily waterbody volume between 6.4 and 11.8 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1122,7 +1122,7 @@ entities:
       -
         attr-label: height_13.2_18.2
         attr-def: >-
-          Meters of the water column between 13.2 and 18.2 degrees C.
+          Annual sum of the daily water column height between 13.2 and 18.2 degrees C.
           This range is used to denote lower good-growth temperature (cool thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1131,7 +1131,7 @@ entities:
       -
         attr-label: vol_13.2_18.2
         attr-def: >-
-          Volume of the waterbody between 13.2 and 18.2 degrees C.
+          Annual sum of the daily waterbody volume between 13.2 and 18.2 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1148,7 +1148,7 @@ entities:
       -
         attr-label: height_17.7_22.5
         attr-def: >-
-          Meters of the water column between 17.7 and 22.5 degrees C.
+          Annual sum of the daily water column height between 17.7 and 22.5 degrees C.
           This range is used to denote lower good-growth temperature (warm thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1157,7 +1157,7 @@ entities:
       -
         attr-label: vol_17.7_22.5
         attr-def: >-
-          Volume of the waterbody between 17.7 and 22.5 degrees C.
+          Annual sum of the daily waterbody volume between 17.7 and 22.5 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1174,7 +1174,7 @@ entities:
       -
         attr-label: height_11.5_18.7
         attr-def: >-
-          Meters of the water column between 11.5 and 18.7 degrees C.
+          Annual sum of the daily water column height between 11.5 and 18.7 degrees C.
           This range is used to denote optimum temperature (cold thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1183,7 +1183,7 @@ entities:
       -
         attr-label: vol_11.5_18.7
         attr-def: >-
-          Volume of the waterbody between 11.5 and 18.7 degrees C.
+          Annual sum of the daily waterbody volume between 11.5 and 18.7 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1200,7 +1200,7 @@ entities:
       -
         attr-label: height_24_25.7
         attr-def: >-
-          Meters of the water column between 24 and 25.7 degrees C.
+          Annual sum of the daily water column height between 24 and 25.7 degrees C.
           This range is used to denote optimum temperature (cool thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1209,7 +1209,7 @@ entities:
       -
         attr-label: vol_24_25.7
         attr-def: >-
-          Volume of the waterbody between 24 and 25.7 degrees C.
+          Annual sum of the daily waterbody volume between 24 and 25.7 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1226,7 +1226,7 @@ entities:
       -
         attr-label: height_27_32
         attr-def: >-
-          Meters of the water column between 27 and 32 degrees C.
+          Annual sum of the daily water column height between 27 and 32 degrees C.
           This range is used to denote optimum temperature (warm thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1235,7 +1235,7 @@ entities:
       -
         attr-label: vol_27_32
         attr-def: >-
-          Volume of the waterbody between 27 and 32 degrees C.
+          Annual sum of the daily waterbody volume between 27 and 32 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1252,7 +1252,7 @@ entities:
       -
         attr-label: height_15.5_21.2
         attr-def: >-
-          Meters of the water column between 15.5 and 21.2 degrees C.
+          Annual sum of the daily water column height between 15.5 and 21.2 degrees C.
           This range is used to denote upper good growth temperature (cold thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1261,7 +1261,7 @@ entities:
       -
         attr-label: vol_15.5_21.2
         attr-def: >-
-          Volume of the waterbody between 15.5 and 21.2 degrees C.
+          Annual sum of the daily waterbody volume between 15.5 and 21.2 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1278,7 +1278,7 @@ entities:
       -
         attr-label: height_27.7_28.8
         attr-def: >-
-          Meters of the water column between 27.7 and 28.8 degrees C.
+          Annual sum of the daily water column height between 27.7 and 28.8 degrees C.
           This range is used to denote upper good growth temperature (cool thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1287,7 +1287,7 @@ entities:
       -
         attr-label: vol_27.7_28.8
         attr-def: >-
-          Volume of the waterbody between 27.7 and 28.8 degrees C.
+          Annual sum of the daily waterbody volume between 27.7 and 28.8 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1304,7 +1304,7 @@ entities:
       -
         attr-label: height_31.3_34.7
         attr-def: >-
-          Meters of the water column between 31.3 and 34.7 degrees C.
+          Annual sum of the daily water column height between 31.3 and 34.7 degrees C.
           This range is used to denote upper good growth temperature (warm thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1313,7 +1313,7 @@ entities:
       -
         attr-label: vol_31.3_34.7
         attr-def: >-
-          Volume of the waterbody between 31.3 and 34.7 degrees C.
+          Annual sum of the daily waterbody volume between 31.3 and 34.7 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1330,7 +1330,7 @@ entities:
       -
         attr-label: height_26.6_100
         attr-def: >-
-          Meters of the water column between 26.6 and 100 degrees C.
+          Annual sum of the daily water column height between 26.6 and 100 degrees C.
           This range is used to denote upper lethal temperature (cold thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1339,7 +1339,7 @@ entities:
       -
         attr-label: vol_26.6_100
         attr-def: >-
-          Volume of the waterbody between 26.6 and 100 degrees C.
+          Annual sum of the daily waterbody volume between 26.6 and 100 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1356,7 +1356,7 @@ entities:
       -
         attr-label: height_32.3_100
         attr-def: >-
-          Meters of the water column between 32.3 and 100 degrees C.
+          Annual sum of the daily water column height between 32.3 and 100 degrees C.
           This range is used to denote upper lethal temperature (cool thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1365,7 +1365,7 @@ entities:
       -
         attr-label: vol_32.3_100
         attr-def: >-
-          Volume of the waterbody between 32.3 and 100 degrees C.
+          Annual sum of the daily waterbody volume between 32.3 and 100 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1382,7 +1382,7 @@ entities:
       -
         attr-label: height_36_100
         attr-def: >-
-          Meters of the water column between 36 and 100 degrees C.
+          Annual sum of the daily water column height between 36 and 100 degrees C.
           This range is used to denote upper lethal temperature (warm thermal guild)
         attr-defs: Eaton et al., 1995
         data-min: NA
@@ -1391,7 +1391,7 @@ entities:
       -
         attr-label: vol_36_100
         attr-def: >-
-          Volume of the waterbody between 36 and 100 degrees C.
+          Annual sum of the daily waterbody volume between 36 and 100 degrees C.
         attr-defs: Eaton et al., 1995
         data-min: NA
         data-max: NA
@@ -1408,7 +1408,7 @@ entities:
       -
         attr-label: height_12_28
         attr-def: >-
-          Meters of the water column between 12 and 28 degrees C.
+          Annual sum of the daily water column height between 12 and 28 degrees C.
           This range is used to denote optimal age 0 thermal habitat
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1417,7 +1417,7 @@ entities:
       -
         attr-label: vol_12_28
         attr-def: >-
-          Volume of the waterbody between 12 and 28 degrees C.
+          Annual sum of the daily waterbody volume between 12 and 28 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1434,7 +1434,7 @@ entities:
       -
         attr-label: height_10.6_11.2
         attr-def: >-
-          Meters of the water column between 10.6 and 11.2 degrees C.
+          Annual sum of the daily water column height between 10.6 and 11.2 degrees C.
           This range is used to denote optimal larval thermal habitat
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1443,7 +1443,7 @@ entities:
       -
         attr-label: vol_10.6_11.2
         attr-def: >-
-          Volume of the waterbody between 10.6 and 11.2 degrees C.
+          Annual sum of the daily waterbody volume between 10.6 and 11.2 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1460,7 +1460,7 @@ entities:
       -
         attr-label: height_18.2_28.2
         attr-def: >-
-          Meters of the water column between 18.2 and 28.2 degrees C.
+          Annual sum of the daily water column height between 18.2 and 28.2 degrees C.
           This range is used to denote good growth habitat
         attr-defs: Fang et al., 2004
         data-min: NA
@@ -1469,7 +1469,7 @@ entities:
       -
         attr-label: vol_18.2_28.2
         attr-def: >-
-          Volume of the waterbody between 18.2 and 28.2 degrees C.
+          Annual sum of the daily waterbody volume between 18.2 and 28.2 degrees C.
         attr-defs: Fang et al., 2004
         data-min: NA
         data-max: NA
@@ -1486,7 +1486,7 @@ entities:
       -
         attr-label: height_18_22
         attr-def: >-
-          Meters of the water column between 18 and 22 degrees C.
+          Annual sum of the daily water column height between 18 and 22 degrees C.
           This range is used to denote optimal age 0 thermal habitat
         attr-defs: Christie and Regier, 1988
         data-min: NA
@@ -1495,7 +1495,7 @@ entities:
       -
         attr-label: vol_18_22
         attr-def: >-
-          Volume of the waterbody between 18 and 22 degrees C.
+          Annual sum of the daily waterbody volume between 18 and 22 degrees C.
         attr-defs: Christie and Regier, 1988
         data-min: NA
         data-max: NA
@@ -1512,7 +1512,7 @@ entities:
       -
         attr-label: height_19.3_23.3
         attr-def: >-
-          Meters of the water column between 19.3 and 23.3 degrees C.
+          Annual sum of the daily water column height between 19.3 and 23.3 degrees C.
           This range is used to denote YOY optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1521,7 +1521,7 @@ entities:
       -
         attr-label: vol_19.3_23.3
         attr-def: >-
-          Volume of the waterbody between 19.3 and 23.3 degrees C.
+          Annual sum of the daily waterbody volume between 19.3 and 23.3 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1538,7 +1538,7 @@ entities:
       -
         attr-label: height_19_23
         attr-def: >-
-          Meters of the water column between 19 and 23 degrees C.
+          Annual sum of the daily water column height between 19 and 23 degrees C.
           This range is used to denote optimal thermal habitat
         attr-defs: Cline et al., 2013
         data-min: NA
@@ -1547,7 +1547,7 @@ entities:
       -
         attr-label: vol_19_23
         attr-def: >-
-          Volume of the waterbody between 19 and 23 degrees C.
+          Annual sum of the daily waterbody volume between 19 and 23 degrees C.
         attr-defs: Cline et al., 2013
         data-min: NA
         data-max: NA
@@ -1564,7 +1564,7 @@ entities:
       -
         attr-label: height_20.6_23.2
         attr-def: >-
-          Meters of the water column between 20.6 and 23.2 degrees C.
+          Annual sum of the daily water column height between 20.6 and 23.2 degrees C.
           This range is used to denote optimal thermal habitat
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1573,7 +1573,7 @@ entities:
       -
         attr-label: vol_20.6_23.2
         attr-def: >-
-          Volume of the waterbody between 20.6 and 23.2 degrees C.
+          Annual sum of the daily waterbody volume between 20.6 and 23.2 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1590,7 +1590,7 @@ entities:
       -
         attr-label: height_20_30
         attr-def: >-
-          Meters of the water column between 20 and 30 degrees C.
+          Annual sum of the daily water column height between 20 and 30 degrees C.
           This range is used to denote larval optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1599,7 +1599,7 @@ entities:
       -
         attr-label: vol_20_30
         attr-def: >-
-          Volume of the waterbody between 20 and 30 degrees C.
+          Annual sum of the daily waterbody volume between 20 and 30 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1616,7 +1616,7 @@ entities:
       -
         attr-label: height_21_100
         attr-def: >-
-          Meters of the water column between 21 and 100 degrees C.
+          Annual sum of the daily water column height between 21 and 100 degrees C.
           This range is used to denote growing season for YOY
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1625,7 +1625,7 @@ entities:
       -
         attr-label: vol_21_100
         attr-def: >-
-          Volume of the waterbody between 21 and 100 degrees C.
+          Annual sum of the daily waterbody volume between 21 and 100 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1642,7 +1642,7 @@ entities:
       -
         attr-label: height_22_23
         attr-def: >-
-          Meters of the water column between 22 and 23 degrees C.
+          Annual sum of the daily water column height between 22 and 23 degrees C.
           This range is used to denote optimal thermal habitat
         attr-defs: Casselman, 2002
         data-min: NA
@@ -1651,7 +1651,7 @@ entities:
       -
         attr-label: vol_22_23
         attr-def: >-
-          Volume of the waterbody between 22 and 23 degrees C.
+          Annual sum of the daily waterbody volume between 22 and 23 degrees C.
         attr-defs: Casselman, 2002
         data-min: NA
         data-max: NA
@@ -1668,7 +1668,7 @@ entities:
       -
         attr-label: height_23_31
         attr-def: >-
-          Meters of the water column between 23 and 31 degrees C.
+          Annual sum of the daily water column height between 23 and 31 degrees C.
           This range is used to denote juvenile optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1677,7 +1677,7 @@ entities:
       -
         attr-label: vol_23_31
         attr-def: >-
-          Volume of the waterbody between 23 and 31 degrees C.
+          Annual sum of the daily waterbody volume between 23 and 31 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1694,7 +1694,7 @@ entities:
       -
         attr-label: height_25_29
         attr-def: >-
-          Meters of the water column between 25 and 29 degrees C.
+          Annual sum of the daily water column height between 25 and 29 degrees C.
           This range is used to denote larval optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1703,7 +1703,7 @@ entities:
       -
         attr-label: vol_25_29
         attr-def: >-
-          Volume of the waterbody between 25 and 29 degrees C.
+          Annual sum of the daily waterbody volume between 25 and 29 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1720,7 +1720,7 @@ entities:
       -
         attr-label: height_26.2_32
         attr-def: >-
-          Meters of the water column between 26.2 and 32 degrees C.
+          Annual sum of the daily water column height between 26.2 and 32 degrees C.
           This range is used to denote good growth habitat
         attr-defs: Countant, 1977
         data-min: NA
@@ -1729,7 +1729,7 @@ entities:
       -
         attr-label: vol_26.2_32
         attr-def: >-
-          Volume of the waterbody between 26.2 and 32 degrees C.
+          Annual sum of the daily waterbody volume between 26.2 and 32 degrees C.
         attr-defs: Countant, 1977
         data-min: NA
         data-max: NA
@@ -1746,7 +1746,7 @@ entities:
       -
         attr-label: height_26_28
         attr-def: >-
-          Meters of the water column between 26 and 28 degrees C.
+          Annual sum of the daily water column height between 26 and 28 degrees C.
           This range is used to denote subadult optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1755,7 +1755,7 @@ entities:
       -
         attr-label: vol_26_28
         attr-def: >-
-          Volume of the waterbody between 26 and 28 degrees C.
+          Annual sum of the daily waterbody volume between 26 and 28 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1772,7 +1772,7 @@ entities:
       -
         attr-label: height_26_30
         attr-def: >-
-          Meters of the water column between 26 and 30 degrees C.
+          Annual sum of the daily water column height between 26 and 30 degrees C.
           This range is used to denote adult optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1781,7 +1781,7 @@ entities:
       -
         attr-label: vol_26_30
         attr-def: >-
-          Volume of the waterbody between 26 and 30 degrees C.
+          Annual sum of the daily waterbody volume between 26 and 30 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1798,7 +1798,7 @@ entities:
       -
         attr-label: height_28_29
         attr-def: >-
-          Meters of the water column between 28 and 29 degrees C.
+          Annual sum of the daily water column height between 28 and 29 degrees C.
           This range is used to denote juvenile optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1807,7 +1807,7 @@ entities:
       -
         attr-label: vol_28_29
         attr-def: >-
-          Volume of the waterbody between 28 and 29 degrees C.
+          Annual sum of the daily waterbody volume between 28 and 29 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1825,7 +1825,7 @@ entities:
       -
         attr-label: height_28_32
         attr-def: >-
-          Meters of the water column between 28 and 32 degrees C.
+          Annual sum of the daily water column height between 28 and 32 degrees C.
           This range is used to denote juvenile optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1834,7 +1834,7 @@ entities:
       -
         attr-label: vol_28_32
         attr-def: >-
-          Volume of the waterbody between 28 and 32 degrees C.
+          Annual sum of the daily waterbody volume between 28 and 32 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA
@@ -1852,7 +1852,7 @@ entities:
       -
         attr-label: height_29_100
         attr-def: >-
-          Meters of the water column between 29 and 100 degrees C.
+          Annual sum of the daily water column height between 29 and 100 degrees C.
           This range is used to denote lethal habitat
         attr-defs: Fang et al., 2004
         data-min: NA
@@ -1861,7 +1861,7 @@ entities:
       -
         attr-label: vol_29_100
         attr-def: >-
-          Volume of the waterbody between 29 and 100 degrees C.
+          Annual sum of the daily waterbody volume between 29 and 100 degrees C.
         attr-defs: Fang et al., 2004
         data-min: NA
         data-max: NA
@@ -1879,7 +1879,7 @@ entities:
       -
         attr-label: height_30_31
         attr-def: >-
-          Meters of the water column between 30 and 31 degrees C.
+          Annual sum of the daily water column height between 30 and 31 degrees C.
           This range is used to denote adult optimum
         attr-defs: Wismer and Christie, 1987
         data-min: NA
@@ -1888,7 +1888,7 @@ entities:
       -
         attr-label: vol_30_31
         attr-def: >-
-          Volume of the waterbody between 30 and 31 degrees C.
+          Annual sum of the daily waterbody volume between 30 and 31 degrees C.
         attr-defs: Wismer and Christie, 1987
         data-min: NA
         data-max: NA

--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -1055,7 +1055,8 @@ entities:
         attr-label: mean_{depth}_JulAugSep
         attr-def: >-
           Mean summer (July, August, September) temperature at {depth}. {depth} is
-          either "surf" for surface or "bot" for bottom.
+          either "surf" for surface or "bot" for bottom. The lake bottom is considered 
+          0.1 m from the max depth on that day.
         attr-defs: Read et al., 2021
         data-min: NA
         data-max: NA
@@ -1064,7 +1065,8 @@ entities:
         attr-label: max_{depth}_JulAugSep
         attr-def: >-
           Maximum summer (July, August, September) temperature at {depth}. {depth} is
-          either "surf" for surface or "bot" for bottom.
+          either "surf" for surface or "bot" for bottom. The lake bottom is considered 
+          0.1 m from the max depth on that day.
         attr-defs: Read et al., 2021
         data-min: NA
         data-max: NA
@@ -1073,7 +1075,8 @@ entities:
         attr-label: mean_{depth}_{month}
         attr-def: >-
           Mean temperature at {depth} for {month}. {depth} is either "surf" for
-          surface or "bot" for bottom. {month} is the 3 letter abbreviation for one
+          surface or "bot" for bottom. The lake bottom is considered 0.1 m from the max 
+          depth on that day. {month} is the 3 letter abbreviation for one
           of the 12 months, Jan through Dec.
         attr-defs: Read et al., 2021
         data-min: NA
@@ -1083,7 +1086,8 @@ entities:
         attr-label: max_{depth}_{month}
         attr-def: >-
           Maximum temperature at {depth} for {month}. {depth} is either "surf" for
-          surface or "bot" for bottom. {month} is the 3 letter abbreviation for one
+          surface or "bot" for bottom. The lake bottom is considered 0.1 m from the max 
+          depth on that day. {month} is the 3 letter abbreviation for one
           of the 12 months, Jan (January) through Dec (December).
         attr-defs: Read et al., 2021
         data-min: NA


### PR DESCRIPTION
Addresses all but one thing in #54 (still need to explain `NA` vals in `mean_bottom_{dec, jan, feb}` but thinking that might be helped by the explanation from #53). 

1. Clarifies what is meant by "bottom" in all attribute definitions where it is referenced
2. Adjust definitions for the series of `height_` and `volume_` metrics to explain that they are annual sums
3. Rearranged the order so that it followed the same order as the outputs (that is why entries from `spring_days_in_10.5_15.5` through `open_water_duration` look like they were added then deleted)
4. Added what `NA` meant for each column with NAs where it wasn't already specified 
5. Realized I was missing an entry for the `date_below_5` column, so that was added!